### PR TITLE
Handle encryption of job variables

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.2.2
+version=0.2.3
 groupId=jsr223
 artifactId=jsr223-powershell
 schedulingVersion=+

--- a/src/main/java/jsr223/powershell/CSharpJavaConverter.java
+++ b/src/main/java/jsr223/powershell/CSharpJavaConverter.java
@@ -100,8 +100,10 @@ public class CSharpJavaConverter {
             return cSharpList;
         } else if (bindingValue instanceof VariablesMap) {
             VariablesMap variablesMapBinding = (VariablesMap) bindingValue;
-            return psCaller.createVariablesMap(convertMap(psCaller, variablesMapBinding.getInheritedMap()),
-                                               convertMap(psCaller, convertScopeMap(variablesMapBinding)),
+            return psCaller.createVariablesMap(convertMap(psCaller,
+                                                          convertVariableMap(variablesMapBinding.getInheritedMap())),
+                                               convertMap(psCaller,
+                                                          convertVariableMap(variablesMapBinding.getScopeMap())),
                                                convertMap(psCaller, variablesMapBinding.getScriptMap()));
         } else if (bindingValue instanceof Map) {
             return convertMap(psCaller, (Map) bindingValue);
@@ -124,15 +126,13 @@ public class CSharpJavaConverter {
         return null;
     }
 
-    private static Map<String, Serializable> convertScopeMap(VariablesMap variablesMapBinding) {
-        Map<String, Serializable> scopeMap = variablesMapBinding.getScopeMap();
+    private static Map<String, Serializable> convertVariableMap(Map<String, Serializable> variableMap) {
         Map<String, Serializable> convertedScopeMap = new LinkedHashMap<>();
-        for (Map.Entry<String, Serializable> entry : scopeMap.entrySet()) {
+        for (Map.Entry<String, Serializable> entry : variableMap.entrySet()) {
             Serializable value = entry.getValue();
             if (value != null && value instanceof String && value.toString().startsWith("ENC(")) {
-                String encryptedValue = ((String) value).substring(4, ((String) value).length() - 1);
                 // if the value is encrypted, use the variables map global get method to decrypt it
-                convertedScopeMap.put(entry.getKey(), PropertyDecrypter.getDefaultEncryptor().decrypt(encryptedValue));
+                convertedScopeMap.put(entry.getKey(), PropertyDecrypter.decryptData((String) value));
             } else {
                 convertedScopeMap.put(entry.getKey(), entry.getValue());
             }

--- a/src/test/java/jsr223/powershell/ScriptEngineBindingAndResultTest.java
+++ b/src/test/java/jsr223/powershell/ScriptEngineBindingAndResultTest.java
@@ -42,6 +42,7 @@ import javax.xml.crypto.Data;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.ow2.proactive.core.properties.PropertyDecrypter;
 import org.ow2.proactive.scheduler.common.SchedulerConstants;
 import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
 import org.ow2.proactive.scheduler.task.utils.VariablesMap;
@@ -185,6 +186,8 @@ public class ScriptEngineBindingAndResultTest {
         // and that the original java binding is preserved after the script execution
         VariablesMap map = new VariablesMap();
         map.getScopeMap().put("scopeVar", "value");
+        map.getScopeMap().put("pwd", PropertyDecrypter.encryptData("password"));
+        map.getInheritedMap().put("pwd2", PropertyDecrypter.encryptData("password"));
         // we use a TaskFlowJob as a non-convertible object
         TaskFlowJob job = new TaskFlowJob();
         map.getInheritedMap().put("unconvertible", job);
@@ -213,6 +216,15 @@ public class ScriptEngineBindingAndResultTest {
         Assert.assertTrue(((String) unconvertibleVariable).startsWith(CSharpJavaConverter.NOT_SUPPORTED_JAVA_OBJECT));
         Assert.assertEquals(job, map.getPropagatedVariables().get("unconvertible"));
         System.out.println(map);
+
+        Object encryptedVariable = scriptEngine.eval("$" + SchedulerConstants.VARIABLES_BINDING_NAME +
+                                                     ".Get_Item('pwd')");
+        Assert.assertTrue(scopeVariable instanceof String);
+        Assert.assertEquals("password", encryptedVariable);
+
+        encryptedVariable = scriptEngine.eval("$" + SchedulerConstants.VARIABLES_BINDING_NAME + ".Get_Item('pwd2')");
+        Assert.assertTrue(scopeVariable instanceof String);
+        Assert.assertEquals("password", encryptedVariable);
     }
 
 }


### PR DESCRIPTION
Previous fix managed to handle encryption of task variables only (and not job variables).